### PR TITLE
chore: Moves the get_version to the fetch.py module

### DIFF
--- a/examples/sec-sentiment-analysis/fetch.py
+++ b/examples/sec-sentiment-analysis/fetch.py
@@ -222,3 +222,13 @@ def _get_session(company: Optional[str] = None, email: Optional[str] = None) -> 
         }
     )
     return session
+
+
+def get_version():
+    """Pulls the current version of the pipeline API from the GitHub repo."""
+    api_yaml_url = "https://raw.githubusercontent.com/Unstructured-IO/pipeline-sec-filings/main/preprocessing-pipeline-family.yaml"
+    yaml_content = requests.get(api_yaml_url).text
+    for tokens in [line.split(" ") for line in yaml_content.split("\n")]:
+        if tokens[0] == "version:":
+            return tokens[1]
+    raise ValueError("Version not found")

--- a/examples/sec-sentiment-analysis/sec-sentiment-analysis.ipynb
+++ b/examples/sec-sentiment-analysis/sec-sentiment-analysis.ipynb
@@ -118,7 +118,8 @@
    "outputs": [],
    "source": [
     "import requests\n",
-    "import time"
+    "import time\n",
+    "from fetch import get_version"
    ]
   },
   {
@@ -126,18 +127,19 @@
    "execution_count": null,
    "id": "dc99e2be",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://api.unstructured.io/sec-filings/v0.2.0/section\n"
+     ]
+    }
+   ],
    "source": [
-    "def _get_version():\n",
-    "    \"\"\"quick and dirty yaml version parser\"\"\"\n",
-    "    api_yaml_url = \"https://raw.githubusercontent.com/Unstructured-IO/pipeline-sec-filings/main/preprocessing-pipeline-family.yaml\"\n",
-    "    yaml_content = requests.get(api_yaml_url).text\n",
-    "    for tokens in [line.split(\" \") for line in yaml_content.split(\"\\n\")]:\n",
-    "        if tokens[0] == \"version:\":\n",
-    "            return tokens[1]\n",
-    "    raise ValueError(\"Version not found\")\n",
-    "\n",
-    "url = f\"https://api.unstructured.io/sec-filings/v{_get_version()}/section\""
+    "version = get_version()\n",
+    "url = f\"https://api.unstructured.io/sec-filings/v{version}/section\"\n",
+    "print(url)"
    ]
   },
   {
@@ -219,68 +221,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ca970f84ff604aaa944aea2e34b90e64",
+       "model_id": "03ab9401f78e4acaa513ea269e95cfd6",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Downloading:   0%|          | 0.00/629 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "71cf36e816a74d12b9d7a7ac992b0d5e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading:   0%|          | 0.00/5.44k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "81e47e60b5fd4498a085dfb41616a31a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading:   0%|          | 0.00/268M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7bb1c855cfab425a9d4ede04a3b9b933",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading:   0%|          | 0.00/48.0 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "087295e500f646d8bb60a20827e65d25",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading:   0%|          | 0.00/232k [00:00<?, ?B/s]"
+       "Downloading:   0%|          | 0.00/5.47k [00:00<?, ?B/s]"
       ]
      },
      "metadata": {},
@@ -324,7 +270,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ".........................................................."
+      "..............................................................."
      ]
     }
    ],
@@ -469,10 +415,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Some weights of the model checkpoint at distilbert-base-uncased were not used when initializing DistilBertForSequenceClassification: ['vocab_layer_norm.weight', 'vocab_projector.weight', 'vocab_layer_norm.bias', 'vocab_projector.bias', 'vocab_transform.bias', 'vocab_transform.weight']\n",
+      "Some weights of the model checkpoint at distilbert-base-uncased were not used when initializing DistilBertForSequenceClassification: ['vocab_projector.weight', 'vocab_transform.bias', 'vocab_projector.bias', 'vocab_transform.weight', 'vocab_layer_norm.weight', 'vocab_layer_norm.bias']\n",
       "- This IS expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
       "- This IS NOT expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n",
-      "Some weights of DistilBertForSequenceClassification were not initialized from the model checkpoint at distilbert-base-uncased and are newly initialized: ['pre_classifier.weight', 'pre_classifier.bias', 'classifier.weight', 'classifier.bias']\n",
+      "Some weights of DistilBertForSequenceClassification were not initialized from the model checkpoint at distilbert-base-uncased and are newly initialized: ['pre_classifier.weight', 'classifier.bias', 'classifier.weight', 'pre_classifier.bias']\n",
       "You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.\n"
      ]
     }
@@ -517,7 +463,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7ea830c604bf44d890182dea9dbfbb44",
+       "model_id": "3fed372b9f25407ead2687d96fa38d93",
        "version_major": 2,
        "version_minor": 0
       },
@@ -599,7 +545,7 @@
        "    <div>\n",
        "      \n",
        "      <progress value='939' max='939' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      [939/939 19:39, Epoch 3/3]\n",
+       "      [939/939 18:43, Epoch 3/3]\n",
        "    </div>\n",
        "    <table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
@@ -611,7 +557,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>500</td>\n",
-       "      <td>0.236800</td>\n",
+       "      <td>0.233400</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table><p>"
@@ -642,7 +588,7 @@
     {
      "data": {
       "text/plain": [
-       "TrainOutput(global_step=939, training_loss=0.17356592651627187, metrics={'train_runtime': 1180.7583, 'train_samples_per_second': 6.349, 'train_steps_per_second': 0.795, 'total_flos': 489859524447516.0, 'train_loss': 0.17356592651627187, 'epoch': 3.0})"
+       "TrainOutput(global_step=939, training_loss=0.1685810637550232, metrics={'train_runtime': 1125.0908, 'train_samples_per_second': 6.663, 'train_steps_per_second': 0.835, 'total_flos': 489859524447516.0, 'train_loss': 0.1685810637550232, 'epoch': 3.0})"
       ]
      },
      "execution_count": null,
@@ -798,7 +744,7 @@
     {
      "data": {
       "text/plain": [
-       "[{'label': 'LABEL_0', 'score': 0.9987315535545349}]"
+       "[{'label': 'LABEL_0', 'score': 0.9983240962028503}]"
       ]
      },
      "execution_count": null,
@@ -867,8 +813,8 @@
     {
      "data": {
       "text/plain": [
-       "[{'label': 'LABEL_0', 'score': 0.9987959861755371},\n",
-       " {'label': 'LABEL_0', 'score': 0.9988677501678467}]"
+       "[{'label': 'LABEL_0', 'score': 0.9982876181602478},\n",
+       " {'label': 'LABEL_0', 'score': 0.9985221028327942}]"
       ]
      },
      "execution_count": null,


### PR DESCRIPTION
### Summary

Move the `get_version` helper function to the `fetch.py` module to keep the notebook cleaner and more focused.