### PR TITLE
docs: Basic install instructions for pyenv-virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ structured data from unstructured raw documents.
 
 Unstructured's open-source packages currently target Python 3.8. If you are using or contributing
 to Unstructured code, we encourage you to work with Python 3.8 in a virtual environment. You can
-use the following instructions to get up and running with a Python 3.8 virtual environemtn
+use the following instructions to get up and running with a Python 3.8 virtual environment
 with `pyenv-virtualenv`:
 
 #### Mac / Homebrew

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ with `pyenv-virtualenv`:
 
 #### Mac / Homebrew
 
-1. Install `pyenv-virtualenv` with `brew install pyenv-virtualenv`
-2. Next, use the following commands to add the `pyenv-virtualenv` startup code to `~/.bash_profile`
+1. Install `pyenv` with `brew install pyenv`.
+2. Install `pyenv-virtualenv` with `brew install pyenv-virtualenv`
+3. Next, use the following commands to add the `pyenv-virtualenv` startup code to `~/.bash_profile`
 
 ```
 echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
@@ -24,8 +25,8 @@ echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.
 echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
 ```
 
-3. Install Python 3.8 by running `pyenv install 3.8.14`.
-4. Create and activate a virtual environment by running:
+4. Install Python 3.8 by running `pyenv install 3.8.14`.
+5. Create and activate a virtual environment by running:
 
 ```
 pyenv virtualenv 3.8.14 unstructured

--- a/README.md
+++ b/README.md
@@ -17,14 +17,8 @@ with `pyenv-virtualenv`:
 
 1. Install `pyenv` with `brew install pyenv`.
 2. Install `pyenv-virtualenv` with `brew install pyenv-virtualenv`
-3. Next, use the following commands to add the `pyenv-virtualenv` startup code to `~/.bashrc`
-
-```
-echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
-echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
-echo 'eval "$(pyenv init -)"' >> ~/.bashrc
-```
-
+3. Follow the instructions [here](https://github.com/pyenv/pyenv#user-content-set-up-your-shell-environment-for-pyenv)
+   to add the `pyenv-virtualenv` startup code to your terminal profile.
 4. Install Python 3.8 by running `pyenv install 3.8.14`.
 5. Create and activate a virtual environment by running:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,14 @@ environment for the SEC preprocessing, you can run `pyenv virtualenv 3.8.14 sec`
 1. Run `git clone https://github.com/pyenv/pyenv.git ~/.pyenv` to install `pyenv`
 2. Run `git clone https://github.com/pyenv/pyenv-virtualenv.git ~/.pyenv/plugins/pyenv-virtualenv`
    to install `pyenv-virtualenv` as a `pyenv` plugin.
-3. Use the following commands to add the `pyenv-virtualenv` startup code to `~/.bashrc`
+3. Use the following commands to add the `pyenv-virtualenv` startup code to `~/.bashrc`:
+
+```
+echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
+echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
+echo 'eval "$(pyenv init -)"' >> ~/.bashrc
+```
+
 4. Follow steps 4 and 5 from the Mac/Homebrew instructions.
 
 ## Contributions

--- a/README.md
+++ b/README.md
@@ -6,6 +6,44 @@ We are building an ecosystem of preprepocessing pipeline tools for Data Scientis
 and Data Engineers so they may quickly work through the challenge of extracting
 structured data from unstructured raw documents.
 
+## Getting Started
+
+Unstructured's open-source packages currently target Python 3.8. If you are using or contributing
+to Unstructured code, we encourage you to work with Python 3.8 in a virtual environment. You can
+use the following instructions to get up and running with a Python 3.8 virtual environemtn
+with `pyenv-virtualenv`:
+
+#### Mac / Homebrew
+
+1. Install `pyenv-virtualenv` with `brew install pyenv-virtualenv`
+2. Next, use the following commands to add the `pyenv-virtualenv` startup code to `~/.bash_profile`
+
+```
+echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
+echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
+echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
+```
+
+3. Install Python 3.8 by running `pyenv install 3.8.14`.
+4. Create and activate a virtual environment by running:
+
+```
+pyenv virtualenv 3.8.14 unstructured
+pyenv activate unstructured
+```
+
+You can changed the name of the virtual environment from `unstructured` to another name if you're
+creating a virtual environment for a pipeline. For example, if you're a creating a virtual
+environment for the SEC preprocessing, you can run `pyenv virtualenv 3.8.14 sec`.
+
+#### Linux
+
+1. Run `git clone https://github.com/pyenv/pyenv.git ~/.pyenv` to install `pyenv`
+2. Run `git clone https://github.com/pyenv/pyenv-virtualenv.git ~/.pyenv/plugins/pyenv-virtualenv`
+   to install `pyenv-virtualenv` as a `pyenv` plugin.
+3. Use the following commands to add the `pyenv-virtualenv` startup code to `~/.bashrc`
+4. Follow steps 4 and 5 from the Mac/Homebrew instructions.
+
 ## Contributions
 
 We welcome contributions! This repo's [Issues](https://github.com/Unstructured-IO/community-tasks/issues)

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ with `pyenv-virtualenv`:
 
 1. Install `pyenv` with `brew install pyenv`.
 2. Install `pyenv-virtualenv` with `brew install pyenv-virtualenv`
-3. Next, use the following commands to add the `pyenv-virtualenv` startup code to `~/.bash_profile`
+3. Next, use the following commands to add the `pyenv-virtualenv` startup code to `~/.bashrc`
 
 ```
-echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
-echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
-echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
+echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
+echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
+echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 ```
 
 4. Install Python 3.8 by running `pyenv install 3.8.14`.
@@ -42,15 +42,7 @@ environment for the SEC preprocessing, you can run `pyenv virtualenv 3.8.14 sec`
 1. Run `git clone https://github.com/pyenv/pyenv.git ~/.pyenv` to install `pyenv`
 2. Run `git clone https://github.com/pyenv/pyenv-virtualenv.git ~/.pyenv/plugins/pyenv-virtualenv`
    to install `pyenv-virtualenv` as a `pyenv` plugin.
-3. Use the following commands to add the `pyenv-virtualenv` startup code to `~/.bashrc`:
-
-```
-echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
-echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
-echo 'eval "$(pyenv init -)"' >> ~/.bashrc
-```
-
-4. Follow steps 4 and 5 from the Mac/Homebrew instructions.
+4. Follow steps 3-5 from the Mac/Homebrew instructions.
 
 ## Contributions
 


### PR DESCRIPTION
### Summary

Adds detailed docs on how to install `pyenv-virtualenv`. The intent is to link to this documentation in the install instructions in our package and pipeline repos.